### PR TITLE
Remove deprecated filterJson preview feature from Prisma schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+This is a Rush.js monorepo. Use the following commands for development:
+
+### Setup
+- `rush install` - Install dependencies for all packages
+- `rush build` - Build all packages in dependency order
+
+### Testing  
+- `rush test` - Run unit tests across all packages (use -n auto for parallel execution if >50 test cases)
+- `rush e2e` - Run end-to-end test suite (requires Docker)
+- `rush data-test` - Run tests that require git-lfs data files
+
+### Development
+- `rush change -b origin/master` - Create change files after making modifications (required for Rush change management)
+- `rush unify-dependencies` - Unify dependencies across packages (with optional flags: --update, --lower, --major, --dry)
+
+### Working with Individual Packages
+- Navigate to specific package directories under: `evm/`, `substrate/`, `solana/`, `fuel/`, `starknet/`, `tron/`, `typeorm/`, `util/`, `graphql/`, `processor/`, `test/`
+- Each package has its own `package.json` with scripts
+
+## Architecture
+
+### Monorepo Structure
+This is a TypeScript monorepo supporting multiple blockchain data processing frameworks:
+
+**Core Categories:**
+- `evm/` - Ethereum and EVM-compatible chains (processor, codec, ABI, typegen)
+- `substrate/` - Substrate-based chains (processor, metadata, runtime, typegen) 
+- `solana/` - Solana blockchain support (RPC, stream, objects, normalization)
+- `fuel/` - Fuel blockchain support (data, stream, objects, normalization)
+- `starknet/` - StarkNet blockchain support (data, stream, objects, normalization)
+- `tron/` - TRON blockchain support (data, processor, ingest, normalization)
+- `typeorm/` - Database ORM integration (store, migration, config, codegen)
+- `graphql/` - GraphQL server and openreader components
+- `processor/` - Core batch processing framework
+- `util/` - Shared utilities and internal libraries
+- `test/` - Example projects and test implementations
+
+### Key Architecture Patterns
+- **Processors**: Main entry points for blockchain data ingestion (EVM, Substrate, Solana, etc.)
+- **Codecs**: Binary data encoding/decoding for different chain formats
+- **Typegens**: TypeScript type generation from chain metadata/ABIs
+- **Normalization**: Data transformation and standardization layers
+- **Streams**: Real-time data streaming components
+
+### Change Management
+Uses Rush change files system - always run `rush change -b origin/master` after making changes to document modifications for changelog generation.
+
+### Node.js Support
+Requires Node.js >=18.13.1 <23.11.0 as specified in rush.json.
+
+## Development Notes
+
+- The project uses PNPM as the package manager (version 8.8.0)
+- Git LFS is used for large test data files
+- Docker is required for running end-to-end tests
+- All packages follow consistent TypeScript patterns and naming conventions

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ FROM ${node} AS node
 
 
 FROM node AS builder
-RUN apk add g++ make python3 py3-setuptools
+RUN apk add g++ make python3 py3-setuptools openssl libc6-compat
 WORKDIR /squid
 ADD . .
 RUN node common/scripts/install-run-rush.js install
+# RUN cd substrate/substrate-ingest && npx prisma generate
 RUN rm common/config/rush/build-cache.json
 RUN node common/scripts/install-run-rush.js build
 

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   '@keyv/redis':
     specifier: ~2.5.8
     version: 2.5.8(supports-color@8.1.1)
+  '@prisma/client':
+    specifier: ^4.13.0
+    version: 4.16.2(prisma@4.16.2)
   '@rush-temp/astar-erc20':
     specifier: file:./projects/astar-erc20.tgz
     version: file:projects/astar-erc20.tgz(supports-color@8.1.1)(ts-node@10.9.2)
@@ -467,6 +470,9 @@ dependencies:
   pg:
     specifier: ^8.11.3
     version: 8.11.3
+  prisma:
+    specifier: ^4.13.0
+    version: 4.16.2
   prom-client:
     specifier: ^14.2.0
     version: 14.2.0
@@ -1806,6 +1812,29 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@prisma/client@4.16.2(prisma@4.16.2):
+    resolution: {integrity: sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==}
+    engines: {node: '>=14.17'}
+    requiresBuild: true
+    peerDependencies:
+      prisma: '*'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+    dependencies:
+      '@prisma/engines-version': 4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81
+      prisma: 4.16.2
+    dev: false
+
+  /@prisma/engines-version@4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81:
+    resolution: {integrity: sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg==}
+    dev: false
+
+  /@prisma/engines@4.16.2:
+    resolution: {integrity: sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==}
+    requiresBuild: true
+    dev: false
 
   /@protobufjs/aspromise@1.1.2:
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -5715,6 +5744,15 @@ packages:
       react-is: 18.2.0
     dev: false
 
+  /prisma@4.16.2:
+    resolution: {integrity: sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@prisma/engines': 4.16.2
+    dev: false
+
   /prom-client@14.2.0:
     resolution: {integrity: sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==}
     engines: {node: '>=10'}
@@ -6928,7 +6966,7 @@ packages:
     dev: false
 
   file:projects/astar-erc20.tgz(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-h/Ui36RAsNWEr7GB5f8LZirIbM0xKPPnCEg+JzRHIfzx4d9ytFC5IqMD8YmXIdd2Jcu4jJSKlzl3k9RLyag9gQ==, tarball: file:projects/astar-erc20.tgz}
+    resolution: {integrity: sha512-CE05fv+wsudLTDsq3KDiiGGbhLIH5sagfwoM2DSiCQVsFTcrjDjTPEy//6a4NP1HBXuVdmABzldFvRlmJ5YdiQ==, tarball: file:projects/astar-erc20.tgz}
     id: file:projects/astar-erc20.tgz
     name: '@rush-temp/astar-erc20'
     version: 0.0.0
@@ -6962,7 +7000,7 @@ packages:
     dev: false
 
   file:projects/balances.tgz(supports-color@8.1.1):
-    resolution: {integrity: sha512-pVbvU9TudRnslECyftaoS2wfatI4QoSPsSW0vNXYp5G4OqbJgA5pwFiydqUQY9s8YlUscFOS72LYv4nSzUN2zA==, tarball: file:projects/balances.tgz}
+    resolution: {integrity: sha512-GEXeQOsNOdrVj+4P4f1Iwk5Jw71j6YOgOSjY8BroFZNuHgCXvPY3b0g1eWfgDPKbWZMZUVahx5BsqodEWzafWg==, tarball: file:projects/balances.tgz}
     id: file:projects/balances.tgz
     name: '@rush-temp/balances'
     version: 0.0.0
@@ -6995,7 +7033,7 @@ packages:
     dev: false
 
   file:projects/batch-processor.tgz:
-    resolution: {integrity: sha512-B2q6IRhdLOzkr/J1GpIpsq5++s/I8gQALRZlawKo6kNypBN5DdS/S5zswF2mFaaP2MwQkLC4WsWOmEmDqzWVzg==, tarball: file:projects/batch-processor.tgz}
+    resolution: {integrity: sha512-dK4qzaSDEQ2GqjxfXf587Uapenf8tx+3/DlS/C8joKIPDtOyjp5pOWajs+cKrITvKcyZyNqHlbUvPoQGpvsVlQ==, tarball: file:projects/batch-processor.tgz}
     name: '@rush-temp/batch-processor'
     version: 0.0.0
     dependencies:
@@ -7005,7 +7043,7 @@ packages:
     dev: false
 
   file:projects/big-decimal.tgz:
-    resolution: {integrity: sha512-S6B1X7Hu9b+KPnj+yYHceoBBPOayTUGtA/V+8BsezCola/PGe2BsA30qhTX+vIA3NKUMqF3fue8ZJdSoPDtFsg==, tarball: file:projects/big-decimal.tgz}
+    resolution: {integrity: sha512-/Er4O4+BTjIgMcLL/oy3KUDz5o/97kqUHu1HGrIvixflTucO3M2Dm/GnwE1d81EtsEaCR57yWvZ7u07HLEU3og==, tarball: file:projects/big-decimal.tgz}
     name: '@rush-temp/big-decimal'
     version: 0.0.0
     dependencies:
@@ -7013,7 +7051,7 @@ packages:
     dev: false
 
   file:projects/borsh-bench.tgz:
-    resolution: {integrity: sha512-GoO/8An0JrgO2FInOFVDaY8LNHk+tAO8Ek1Nfq+k/IJkBYkfvFllnk5C2xJ/qu/cAnPGWcQmSw5PjSFsqsXlPw==, tarball: file:projects/borsh-bench.tgz}
+    resolution: {integrity: sha512-sNeVDUwWOUHzoB7j8klY/WyjaNPzaVg7UU4H7OQAS9UhAtVuexcA2/fbIBIbf31WzUAUGXViSvP743YSCPJYcg==, tarball: file:projects/borsh-bench.tgz}
     name: '@rush-temp/borsh-bench'
     version: 0.0.0
     dependencies:
@@ -7029,7 +7067,7 @@ packages:
     dev: false
 
   file:projects/borsh.tgz:
-    resolution: {integrity: sha512-KFzv6JCD2pV/jBzBFGP49dyN9Nr8MngkD+pdJ/JksFLJL9AevSqPRApEOuqNM+U4nTGrvWJ3E9laA+6aYddcqA==, tarball: file:projects/borsh.tgz}
+    resolution: {integrity: sha512-60LwkS+CifaJjQvpgyFZEgdhuktL5Nj6JOHMkxBTnN2nUei2WtZpaMeH9Dx0XqbRGovm2xQq1rSvtaDpxhL1Xg==, tarball: file:projects/borsh.tgz}
     name: '@rush-temp/borsh'
     version: 0.0.0
     dependencies:
@@ -7039,7 +7077,7 @@ packages:
     dev: false
 
   file:projects/commands.tgz:
-    resolution: {integrity: sha512-RVNP+Jfp+ShgvwXZaP6/YkaTEL9JL6diOBXVGHGym2n1rAeV3gn1E6lHKdPlZMiTr8pXN0a4VqpyJbRG5jxJyQ==, tarball: file:projects/commands.tgz}
+    resolution: {integrity: sha512-pAQGRTCj1ajZ/KmD0bwdYsUdg14TwpNljdxKolaZ7pr4fgHJGTL8f9w/jDlpqRK8ZwzFmsisQrGkcpbEAKWHGg==, tarball: file:projects/commands.tgz}
     name: '@rush-temp/commands'
     version: 0.0.0
     dependencies:
@@ -7052,7 +7090,7 @@ packages:
     dev: false
 
   file:projects/data-test.tgz:
-    resolution: {integrity: sha512-2ornWKxbQjXLKCJS4UZK3Vcsbrd6Zq1vCQetS+t5ZFY/5RahguFxUUljp8W8QaC3gqXsrvlnmGQxZ1ZmAUsO8g==, tarball: file:projects/data-test.tgz}
+    resolution: {integrity: sha512-0ZSEset0i1UsAsrxM5PPhampw6TwUyFa4HJMkU4kTlSftS9ef7/MeqWGrZcrkquoynqoNqk2iKe8uBkX1rURiw==, tarball: file:projects/data-test.tgz}
     name: '@rush-temp/data-test'
     version: 0.0.0
     dependencies:
@@ -7066,7 +7104,7 @@ packages:
     dev: false
 
   file:projects/erc20-transfers.tgz(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-MR3ZHLJ0v315saPxL1M01gdBzriD6pWwqRPCmFNXP6vL7MV1vYzUCBlcNKPIjGHMB03K+uBYUEJSgWA8FrOHwQ==, tarball: file:projects/erc20-transfers.tgz}
+    resolution: {integrity: sha512-YKdaPpCObatuBMnJ32kEnR0ymBpqkO6Z7dj3HkX08R9lByCd589GrRQsLRbVCH81zlb71fSbV6OopY7dhE3nQQ==, tarball: file:projects/erc20-transfers.tgz}
     id: file:projects/erc20-transfers.tgz
     name: '@rush-temp/erc20-transfers'
     version: 0.0.0
@@ -7100,7 +7138,7 @@ packages:
     dev: false
 
   file:projects/evm-abi.tgz(supports-color@8.1.1):
-    resolution: {integrity: sha512-i04N31pqhrikZ8ZqT0tTqeEQY9U2kGK4M+JF4SwLsaUGbA/k3hlbBGyAK4Z0CAe+7ONPoQnlWaoyJV+Rs8g/6A==, tarball: file:projects/evm-abi.tgz}
+    resolution: {integrity: sha512-akP6taJd7t3JcPw/r2gOBNmm1VqGbbEx6ad4t2ltabDhoK9afVZwjl7yWX0tN29I2iNAS13em4vD9DJaL19Sew==, tarball: file:projects/evm-abi.tgz}
     id: file:projects/evm-abi.tgz
     name: '@rush-temp/evm-abi'
     version: 0.0.0
@@ -7131,7 +7169,7 @@ packages:
     dev: false
 
   file:projects/evm-codec.tgz(supports-color@8.1.1):
-    resolution: {integrity: sha512-80m1m+Zpii/ktnhzKs0Td0KIDax/EacAPBFAssnt+x6ZZbNajyzzuiY4PJMT6G3UjM4QtkMC6l8SOZLtz2VyRQ==, tarball: file:projects/evm-codec.tgz}
+    resolution: {integrity: sha512-RgfC5WBOUOOWbif7FcBtUzEaj9K6e85KDi8aDdv6/cZ6yw/uvfqQilRD58uNgfLOn72sysXs0WvrdVvnjC/vTQ==, tarball: file:projects/evm-codec.tgz}
     id: file:projects/evm-codec.tgz
     name: '@rush-temp/evm-codec'
     version: 0.0.0
@@ -7161,7 +7199,7 @@ packages:
     dev: false
 
   file:projects/evm-processor.tgz:
-    resolution: {integrity: sha512-omgyrH0IpC0kQaIofx1ljRz+1CM5b4ie/3QouMbLswMez0CD2Md+MkTcF8DdoezYDq8QqfLlMA4+AhLwCl9OXw==, tarball: file:projects/evm-processor.tgz}
+    resolution: {integrity: sha512-YbM/JSqaEzlRlhTzZSoK7OJlTwpgk85xYiPoPWIkkjnoND8JNKtDAcif7VzlmWyvO/ThgUu4fyWt23PIfsLN1g==, tarball: file:projects/evm-processor.tgz}
     name: '@rush-temp/evm-processor'
     version: 0.0.0
     dependencies:
@@ -7170,7 +7208,7 @@ packages:
     dev: false
 
   file:projects/evm-typegen.tgz:
-    resolution: {integrity: sha512-wcHeODA0T8OPlAvZuo0OaoKzbz4iekJ+YVe76UpflD/E+ShtiXDW9x0C14qOprQMncV9ZaolkbHpmWZHHRCW+w==, tarball: file:projects/evm-typegen.tgz}
+    resolution: {integrity: sha512-KKEGxHtiLne0jf0+9M8wPIz6rdiqHpjKPlhKDHRIZB0shzYuK8nOseE0Pvfc9jYNnUst05oeY0EDeoj1F1TnUw==, tarball: file:projects/evm-typegen.tgz}
     name: '@rush-temp/evm-typegen'
     version: 0.0.0
     dependencies:
@@ -7184,7 +7222,7 @@ packages:
     dev: false
 
   file:projects/frontier.tgz:
-    resolution: {integrity: sha512-319fwU3iWy9qtqSKGPPM0OWFoDH2or55Gwsb0ziFpbX/dFeFnjdOsPK2xAKT8mnnRDmuttI/8MZX3DpWnreeJw==, tarball: file:projects/frontier.tgz}
+    resolution: {integrity: sha512-0GimxrR29PZcl1XRaw8JwulskTxUdoQJCmxKsCcx0+GSB/kGBh2l13/IvFHyhQPW4IA0Llq19FugFxfoQj0Hmg==, tarball: file:projects/frontier.tgz}
     name: '@rush-temp/frontier'
     version: 0.0.0
     dependencies:
@@ -7201,7 +7239,7 @@ packages:
     dev: false
 
   file:projects/fuel-data.tgz:
-    resolution: {integrity: sha512-kY4TDHCO+yBPzwojzGpe7Kt1sQ9VFTWO0uTM1Tvu14h2u34kp99GSP2BNQ19PJNSQ7R7+8f4Y63oTcNBstsChA==, tarball: file:projects/fuel-data.tgz}
+    resolution: {integrity: sha512-fDAsp7WR66W3QdL+ldqmZklK6IVhxDRu+h8vbeh4tiITVt5srrBiJMBqKHvyyLj6obbK/z8E5qWAiBOnqGLufg==, tarball: file:projects/fuel-data.tgz}
     name: '@rush-temp/fuel-data'
     version: 0.0.0
     dependencies:
@@ -7210,7 +7248,7 @@ packages:
     dev: false
 
   file:projects/fuel-dump.tgz:
-    resolution: {integrity: sha512-uDZ9pUfzSd9phpWJw/eGMpeGFGQYbFxRvJBPp7a7227eh7jHpBp3e5+FLrQcjE1GtB2+ezfNQgV0cgjESwKh+w==, tarball: file:projects/fuel-dump.tgz}
+    resolution: {integrity: sha512-KsoSMa+332lyf6RsZ8w2ZpqrSFIrqNbO+OslrwVCE6U2/1oec5oVmx0aoe8yEEBnOIFHSqsefmTj1ie6fpFlzw==, tarball: file:projects/fuel-dump.tgz}
     name: '@rush-temp/fuel-dump'
     version: 0.0.0
     dependencies:
@@ -7219,7 +7257,7 @@ packages:
     dev: false
 
   file:projects/fuel-indexer.tgz(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-JxGi/9NHg7kFh4jqOSA2uqgC/X3r78CzK5+pFebfPPZtt4klv9Zn14O9zk7bu7HJGnsw034zXf09q3ELYkGQMg==, tarball: file:projects/fuel-indexer.tgz}
+    resolution: {integrity: sha512-B1hCm0px4HuLo+dmdT7oMdkWPCD4K3Kn+bZqSP3aH95fEoHX7TH15yjFPdYIOARTVm5M1ZVWt+Eadzl4DBbKMg==, tarball: file:projects/fuel-indexer.tgz}
     id: file:projects/fuel-indexer.tgz
     name: '@rush-temp/fuel-indexer'
     version: 0.0.0
@@ -7250,7 +7288,7 @@ packages:
     dev: false
 
   file:projects/fuel-ingest.tgz:
-    resolution: {integrity: sha512-g4dvzKpOqbpgp8K22QTgtOcCzRd/estKCRMRB1i5oULyimE5ErVHwK0cNDSete0aTkNX/Of8awB8Avhx90Ji0g==, tarball: file:projects/fuel-ingest.tgz}
+    resolution: {integrity: sha512-OKxeBLOUIbF10OS9Ib11Kcv+qfUGFF0tYUBL68tk404ywZvj66eVDtMaAAODUciiRT7uLuPaCxbuJm8FuW8CIQ==, tarball: file:projects/fuel-ingest.tgz}
     name: '@rush-temp/fuel-ingest'
     version: 0.0.0
     dependencies:
@@ -7259,7 +7297,7 @@ packages:
     dev: false
 
   file:projects/fuel-normalization.tgz:
-    resolution: {integrity: sha512-fH0fLYswmMQiTLRk/SaUcHSnZujUd4GcO7R2UO4YXlQeXcAQIRSja0w8ExQI5GpSwtNxfJJ9D4QaOlryA1ie2g==, tarball: file:projects/fuel-normalization.tgz}
+    resolution: {integrity: sha512-dHLCf+AQjyEomEskZFWV/a1veQFsuaNkO4UFBc73kEGIfo3IxDGFxbGWAuAsdKkVNBRaAYRtj7h6dmMNMYlLWw==, tarball: file:projects/fuel-normalization.tgz}
     name: '@rush-temp/fuel-normalization'
     version: 0.0.0
     dependencies:
@@ -7268,7 +7306,7 @@ packages:
     dev: false
 
   file:projects/fuel-objects.tgz:
-    resolution: {integrity: sha512-gWMB+Wf6ilxj2j45MZmRv/pYOT72q5OujdAXaE0YqHLW5+OGOtNH2NfoaRb1lEOAO3WUUnAwHyYSXjKzBjtAxQ==, tarball: file:projects/fuel-objects.tgz}
+    resolution: {integrity: sha512-KD6M9uzc+pfNHgVGEmAUAsUszOAYxF2ME7kGiUWR4gC1ugHaC+bSwsD72j0QDE/JSztp3F8iDsDZjCkYqRNUSQ==, tarball: file:projects/fuel-objects.tgz}
     name: '@rush-temp/fuel-objects'
     version: 0.0.0
     dependencies:
@@ -7277,7 +7315,7 @@ packages:
     dev: false
 
   file:projects/fuel-stream.tgz:
-    resolution: {integrity: sha512-UQnZd8XfCcbB3yEiSDJVYCbs+eUCQcburRj82TDhJ+ZhDjHCCs8j/kMS3KnKsi40rIK9PeWL/0/Vl/HWJ4bReA==, tarball: file:projects/fuel-stream.tgz}
+    resolution: {integrity: sha512-RftEplI+zD9xd+xQEF2hnIYGv6u1IS9YvSRkHujHZOsGy7bIqZscJpKO7YkAM3HBREILUE+RS5gUtLcwDEmoEw==, tarball: file:projects/fuel-stream.tgz}
     name: '@rush-temp/fuel-stream'
     version: 0.0.0
     dependencies:
@@ -7286,7 +7324,7 @@ packages:
     dev: false
 
   file:projects/gql-test-client.tgz(graphql@15.8.0):
-    resolution: {integrity: sha512-gY3sATGKJdqn3MUjxkqsprDOiN1Ks2MXC1wLcyJRAhcL17tp9qB9hXV3vha0NtbeD0vIel8TFs38yeqbRJLmeQ==, tarball: file:projects/gql-test-client.tgz}
+    resolution: {integrity: sha512-bivyHNQZ2H4YrNdCo4dwEc53cIe+iXpU2UF6vMjBwbgHqiIbrhGpMbtzgKoZLdNAkbqchh0E543pkDQy318iow==, tarball: file:projects/gql-test-client.tgz}
     id: file:projects/gql-test-client.tgz
     name: '@rush-temp/gql-test-client'
     version: 0.0.0
@@ -7304,7 +7342,7 @@ packages:
     dev: false
 
   file:projects/graphql-server.tgz(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-pqShsaj39GLC5CV4ACSN+nxatgfmrL4XOqRwxR5XSudb89SE4ytKGyGpgju/smdzfUCmWJXQ3QSK78ypAGINzQ==, tarball: file:projects/graphql-server.tgz}
+    resolution: {integrity: sha512-yfxBwurEDHKQ4V8i9FQztVHn1qIc1YwLDwxR4YZ/G0+B+PfNgTy1hAEQ7PFeXBhgSuOZswMTA7wkS6CkkC2J4g==, tarball: file:projects/graphql-server.tgz}
     id: file:projects/graphql-server.tgz
     name: '@rush-temp/graphql-server'
     version: 0.0.0
@@ -7363,7 +7401,7 @@ packages:
     dev: false
 
   file:projects/http-client.tgz:
-    resolution: {integrity: sha512-pUEeDka7By48hsKgwSOjm2cbHuO7K3Xl4fuI7cAvTkLoiTqbiQ9xpxLqZnBg1IV8foaQx0eeu1svX0SjOt1iFQ==, tarball: file:projects/http-client.tgz}
+    resolution: {integrity: sha512-//eqL7xtFkouA5JtNEjvpWFnw/aR0KRB6pi/WKvvuFWMa69llYHfdfBY3EslxE1zvVS4AcQSyjZ8TmjK3CcKxw==, tarball: file:projects/http-client.tgz}
     name: '@rush-temp/http-client'
     version: 0.0.0
     dependencies:
@@ -7373,7 +7411,7 @@ packages:
     dev: false
 
   file:projects/ink-abi.tgz:
-    resolution: {integrity: sha512-xDon+XLbEpt/s+639LvNgQW4+uzKqwmNZVY21g7Rkv5ovmphuelVSr5W3nRjDLz1YyuI1KVkRHppQz0bAmRNXA==, tarball: file:projects/ink-abi.tgz}
+    resolution: {integrity: sha512-FNFW6gZ22XdGLZo37op/U8BS5XSjkZfS6T3+Iwxhh+TIFIMijVceXLaoevp0fFBTmwLOC809DYMKdvIXWcM+UQ==, tarball: file:projects/ink-abi.tgz}
     name: '@rush-temp/ink-abi'
     version: 0.0.0
     dependencies:
@@ -7386,7 +7424,7 @@ packages:
     dev: false
 
   file:projects/ink-typegen.tgz:
-    resolution: {integrity: sha512-xgy3ryiqAZnMad4yMZ/bhHq2dV0Ya9zJvaHqoz+bbSMa4SoxGfKfTjn1V8k8jN7PJV1ypJxD2GKjzO5nQWAEbw==, tarball: file:projects/ink-typegen.tgz}
+    resolution: {integrity: sha512-AU2LucHlRuPmvUmZnD/Vfs/vdrcsC98+AVNLO8qlIuA+RH+yc+CsjhpRwRBGG4jrciJfnpaiHRB2jN7OrUuI6A==, tarball: file:projects/ink-typegen.tgz}
     name: '@rush-temp/ink-typegen'
     version: 0.0.0
     dependencies:
@@ -7396,7 +7434,7 @@ packages:
     dev: false
 
   file:projects/logger.tgz:
-    resolution: {integrity: sha512-0sy0Stybp7aq2aG3Xnef5IUrK6JW0erIOKJTy5c3jCtyu++H1+sEZdGNL3r+ftkfqBjgMZODU1FM3omXvTRBcg==, tarball: file:projects/logger.tgz}
+    resolution: {integrity: sha512-+Kyv4qM60JZ9Pwf4tFaoR/egl0XDQ51CqP0Y04/rp+nllGaEmZiNpwgArccgAprm0A5DUNQC9WQmja06YnWcvg==, tarball: file:projects/logger.tgz}
     name: '@rush-temp/logger'
     version: 0.0.0
     dependencies:
@@ -7410,7 +7448,7 @@ packages:
     dev: false
 
   file:projects/openreader.tgz(supports-color@8.1.1):
-    resolution: {integrity: sha512-yrG6rS2FKr8WFc0z6qlSKnsyeWhQMNUTu3HJfyDfwp2ZvaH6yxmncWPM5SR5PgYhl3Nwjyq823g0KoqqDtBjeA==, tarball: file:projects/openreader.tgz}
+    resolution: {integrity: sha512-cudS6XxydOx3cWdfSJpI6DRniDvw34ZbeNC5CTfPMTUWBXo7bs1MrQZvzDJ0h9PntFnfydotrNuC01INRocUig==, tarball: file:projects/openreader.tgz}
     id: file:projects/openreader.tgz
     name: '@rush-temp/openreader'
     version: 0.0.0
@@ -7450,7 +7488,7 @@ packages:
     dev: false
 
   file:projects/ops-xcm-typegen.tgz:
-    resolution: {integrity: sha512-9Ukus+hDnevYvHNe023+uT8Z6uz/2QD8+n6gnjxaDmlHrh96wQi9d9hox7gaRn0luhXes4q+fyOc3jPcBMBXzA==, tarball: file:projects/ops-xcm-typegen.tgz}
+    resolution: {integrity: sha512-dloBQcSnqeCSA17p/lY/6rfth5tdi80fGGZ9QQyyNjensGQRG0AgvMqSLBD828HRHdWvwbuR7eCX8Q1XRR0ngg==, tarball: file:projects/ops-xcm-typegen.tgz}
     name: '@rush-temp/ops-xcm-typegen'
     version: 0.0.0
     dependencies:
@@ -7459,7 +7497,7 @@ packages:
     dev: false
 
   file:projects/polkavm-erc20.tgz(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-T53CQjkU8OWGxdFPioy0K+vaIYcJCbYvTxrfwkEEwlvU2vfmTmoNwg0kTwFfM8n+Zzlj+KMSJ0SR7iXvFBiA0A==, tarball: file:projects/polkavm-erc20.tgz}
+    resolution: {integrity: sha512-4Fy26LLmgLiIkA3vF46q60Dfy+Hpx0PqVIRumWRsUEdSPV+cLsmE0dpllV4TQKVbA13yIOZCOb6VpdS+idsc7w==, tarball: file:projects/polkavm-erc20.tgz}
     id: file:projects/polkavm-erc20.tgz
     name: '@rush-temp/polkavm-erc20'
     version: 0.0.0
@@ -7490,7 +7528,7 @@ packages:
     dev: false
 
   file:projects/raw-archive-validator.tgz:
-    resolution: {integrity: sha512-XXDqfZYXQ9pv/42aaBgaAf5GV4qWqfNj+qZAEOks8OGvxRIXPR8UFUkI1jDTCSvTNtMz4IikfWqiffQuYeqlTg==, tarball: file:projects/raw-archive-validator.tgz}
+    resolution: {integrity: sha512-Wsp3kiz9gJ27dGeMhIk5+TMX+ASZDZhOXFziwn63Pue9yR0I1wumcbVWTZIakTxdp8fhZy9/pkFPSbtY8n4ytw==, tarball: file:projects/raw-archive-validator.tgz}
     name: '@rush-temp/raw-archive-validator'
     version: 0.0.0
     dependencies:
@@ -7500,7 +7538,7 @@ packages:
     dev: false
 
   file:projects/rpc-client.tgz:
-    resolution: {integrity: sha512-x1UUJIdW4TlCu6t2Ua+R3UbNnp3Xon26WbwznUbYcv5jltbdZb9b+AVEmg6XtB3rkZp+fZRcZHvNRNG7JfgXmw==, tarball: file:projects/rpc-client.tgz}
+    resolution: {integrity: sha512-qsMIEBr8rkuLvap5wzwrSDOlK5Gh3f295ENikiLCYZCRsLTxBJRjtXgiSUlJN4+UCye78CKNStbaTchJvr5fJA==, tarball: file:projects/rpc-client.tgz}
     name: '@rush-temp/rpc-client'
     version: 0.0.0
     dependencies:
@@ -7511,7 +7549,7 @@ packages:
     dev: false
 
   file:projects/scale-codec.tgz:
-    resolution: {integrity: sha512-tvmcUdtoXSnPjI4vup3Z7quG5xq7HCphHUzIQz5MMHkjEiohRMoTYsjEHPGmi5y7ImM6WEgxpdYRg29eKUk0bg==, tarball: file:projects/scale-codec.tgz}
+    resolution: {integrity: sha512-Q5EYxNXxlqvIPkaWBAYYJpXtL6koXAq1dpIS/More49fpmAYU6gZKdv9EtzLNp4IP9O8Ox7fZLZ3zZmzdyoYrQ==, tarball: file:projects/scale-codec.tgz}
     name: '@rush-temp/scale-codec'
     version: 0.0.0
     dependencies:
@@ -7520,7 +7558,7 @@ packages:
     dev: false
 
   file:projects/scale-type-system.tgz:
-    resolution: {integrity: sha512-U3NUjpV8g8+F8QqkYEgovlRYDK6kzzwPjsSm8z4Pw6UfKlXnMQ8eYUREXJHjI+yxr46jD4Aj+xk9KPoiaCafiQ==, tarball: file:projects/scale-type-system.tgz}
+    resolution: {integrity: sha512-DISOYCVSYtuQHL4OAxQhH3XeTump9QT7cJrqLR6tfgpLKHmUx3VjPF4ZdxCmyJtTiWu1QY9AMi/iJKi/zmX48A==, tarball: file:projects/scale-type-system.tgz}
     name: '@rush-temp/scale-type-system'
     version: 0.0.0
     dependencies:
@@ -7529,7 +7567,7 @@ packages:
     dev: false
 
   file:projects/shibuya-erc20.tgz(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-JyaZWYTqvzG9NlQ5rTZ6Ak+7omrrj4JOXee2by6WEXe1FK98XO+D8rsByUiP+cwWb68AcCCTUvG5TUM+giAOaA==, tarball: file:projects/shibuya-erc20.tgz}
+    resolution: {integrity: sha512-Kcq6mGiT4nzftR3h+WZ4KnPaQxwkTyFUI51UJV1j/2OWCBXsRk7uGpM58EshIUL7FHLH5giORGwY8XmpTDKgGQ==, tarball: file:projects/shibuya-erc20.tgz}
     id: file:projects/shibuya-erc20.tgz
     name: '@rush-temp/shibuya-erc20'
     version: 0.0.0
@@ -7560,7 +7598,7 @@ packages:
     dev: false
 
   file:projects/shibuya-psp22.tgz(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-UJrpXlNGwx1Hh8ncBWlKP80cXfsMJeZ1HpDN8vKlcFN6SZGpI/Yq8xLpfgSUU98RRC3AIOzWyYiBEMgITnW8Qg==, tarball: file:projects/shibuya-psp22.tgz}
+    resolution: {integrity: sha512-mjaj1KCH1qiIHNNcI5Sm/ulfAsbcW9WNwPFSqpiZ4NBZfDg/y/Fx4Rr+SR+7wD1zDuBwqvpwYtKDH/j9/rIuwA==, tarball: file:projects/shibuya-psp22.tgz}
     id: file:projects/shibuya-psp22.tgz
     name: '@rush-temp/shibuya-psp22'
     version: 0.0.0
@@ -7591,7 +7629,7 @@ packages:
     dev: false
 
   file:projects/solana-dump.tgz:
-    resolution: {integrity: sha512-InkBLfLXopZDGZRGfJD1DB/+bZK0I0Ivqin/PMHSnRpd2x+S4Gzs5QppB2PgP0FSMn6a3irKeIuaiQh38kfEiA==, tarball: file:projects/solana-dump.tgz}
+    resolution: {integrity: sha512-ADKl8LQM3EtIaN+mFPhfboHOIsu/WKfZ+BgjMyIBWcFtkaHmItm+4m3LgqRx49d/8kn98lsziJPe4cMjRQVoIg==, tarball: file:projects/solana-dump.tgz}
     name: '@rush-temp/solana-dump'
     version: 0.0.0
     dependencies:
@@ -7600,7 +7638,7 @@ packages:
     dev: false
 
   file:projects/solana-example.tgz(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-rtu+dsb/Xmox3DAP3sK+68fDbya/MGj9Gfdru1fENhnHOKOkvBrGzrr3ZIeB73/DIX8je0KccrxUtC+SozUrXg==, tarball: file:projects/solana-example.tgz}
+    resolution: {integrity: sha512-8WqCsK6FGnLqvXXUmhTmTvIHTZzVxXgefA7HPdqOSrUfalr4lLXHoWj6OFyxcfxjU2+aCMlYctCFZ73FNOQV2w==, tarball: file:projects/solana-example.tgz}
     id: file:projects/solana-example.tgz
     name: '@rush-temp/solana-example'
     version: 0.0.0
@@ -7631,7 +7669,7 @@ packages:
     dev: false
 
   file:projects/solana-ingest.tgz:
-    resolution: {integrity: sha512-Oxc0stRqxTCXLfw8P8OzO2Ho5DGuH3DfgD5HtE2+ugQI1tt3H+KSMJPl76fV/w+zA4+KvPl7a8DTe0xBhaq2lA==, tarball: file:projects/solana-ingest.tgz}
+    resolution: {integrity: sha512-l9lmaPc3sgu8mflNH6K+tnYE6tV/rq55GG6YqyqITyh2lH83OLBbcmu9cCK+yYzFQ6JyAKl8E+plIC4uTCc/gQ==, tarball: file:projects/solana-ingest.tgz}
     name: '@rush-temp/solana-ingest'
     version: 0.0.0
     dependencies:
@@ -7640,7 +7678,7 @@ packages:
     dev: false
 
   file:projects/solana-normalization.tgz:
-    resolution: {integrity: sha512-YCQhPGYqFnYLJLUVh3ScICvJoAdqM8MeI2UKgvdnZ+iT95DdtVcWz6N1U53s58XocpNGyODdO5ktag2VQBVVXQ==, tarball: file:projects/solana-normalization.tgz}
+    resolution: {integrity: sha512-IIho93q7BHJPe29Pz8kZ3O7aEql9KH61LSd8Ig9Y00cj8+8DyqzdkogkuPw4VE5WOmCCZgUkNq3GlBmhfgwQlQ==, tarball: file:projects/solana-normalization.tgz}
     name: '@rush-temp/solana-normalization'
     version: 0.0.0
     dependencies:
@@ -7649,7 +7687,7 @@ packages:
     dev: false
 
   file:projects/solana-objects.tgz:
-    resolution: {integrity: sha512-2glYyDYw7QOg6HZ2U1pOnlH5JQ1gSy0BgvtNiKuJvD2LSEwUFxdco3FdwawWdcnByQWTTKqSlR0XKwInewlIBw==, tarball: file:projects/solana-objects.tgz}
+    resolution: {integrity: sha512-LQxMCAc5Mb72dz46dDrgJILS7ApxR5A9O8OHQDGJoNf1y8AqcbW2QoaBs9gaqOYg8fmBjYcQl0Glq07MJNfxFg==, tarball: file:projects/solana-objects.tgz}
     name: '@rush-temp/solana-objects'
     version: 0.0.0
     dependencies:
@@ -7658,7 +7696,7 @@ packages:
     dev: false
 
   file:projects/solana-rpc-data.tgz:
-    resolution: {integrity: sha512-AjGd1ekIh7/nOTCYcOIzx/k9v2swcQ/dchhqSW8MiPlp0R2dv4k5R3yTr5wRv6QIR3RzVg8s8yw64eXuxZC2xg==, tarball: file:projects/solana-rpc-data.tgz}
+    resolution: {integrity: sha512-/blkn5Sks3UrVPWEGTX3qTedNv0v2vkx7UVsPYAhPvtb2SmnmgNYXw41IHCS9N2IZVI/3zNtkNw/wrY8V4Kbiw==, tarball: file:projects/solana-rpc-data.tgz}
     name: '@rush-temp/solana-rpc-data'
     version: 0.0.0
     dependencies:
@@ -7667,7 +7705,7 @@ packages:
     dev: false
 
   file:projects/solana-rpc.tgz:
-    resolution: {integrity: sha512-SIyJ+UQPiq7U6YPrDfn/Bm9j26pOosd7ksZCTsQZ2PPYx7LUP1HybMiOkB8lKvjuSHkB720ATzEMaol8VqklDA==, tarball: file:projects/solana-rpc.tgz}
+    resolution: {integrity: sha512-UBIxbFfqsGGT/yr1pmGALxf/0hziJ71S7GeUhaPSUvEcLoBubeGsz0NN0XVVtnS0QLhZmjpXv/99VGbEQ88unQ==, tarball: file:projects/solana-rpc.tgz}
     name: '@rush-temp/solana-rpc'
     version: 0.0.0
     dependencies:
@@ -7676,7 +7714,7 @@ packages:
     dev: false
 
   file:projects/solana-stream.tgz:
-    resolution: {integrity: sha512-999rQ9oCT8rZHVCcfiZlW+fT2Q7kdyguZYgP+YU1mX/ci1g6WVtl/1f/pe5VUilUDAhQ7qA3U8RR2YGMqEjXEw==, tarball: file:projects/solana-stream.tgz}
+    resolution: {integrity: sha512-rPWYit81qgJcN3zfbtzU5zJisdLYp5AldHXLgga2dcTH3kKI8ek5Tq1sueMtqw7igXy6z/JeE2Ckq32XRHSPFg==, tarball: file:projects/solana-stream.tgz}
     name: '@rush-temp/solana-stream'
     version: 0.0.0
     dependencies:
@@ -7686,7 +7724,7 @@ packages:
     dev: false
 
   file:projects/solana-typegen.tgz:
-    resolution: {integrity: sha512-OslVSySSUnKqhs6IoKL6vn+SF0+jhpEtm/UiXiI3zhZVXMGgTXMgK68N4hW/QcRFoRlcOs8vwRGamhXJb7I8zA==, tarball: file:projects/solana-typegen.tgz}
+    resolution: {integrity: sha512-c2lcrUICOcJ7XiuxuaSVs0OXB0PIKZaFXjYP6qoGK+EPzSBiAICAEKllDcCkstbAP2Q/r54WY/hPk6frieTWqQ==, tarball: file:projects/solana-typegen.tgz}
     name: '@rush-temp/solana-typegen'
     version: 0.0.0
     dependencies:
@@ -7704,7 +7742,7 @@ packages:
     dev: false
 
   file:projects/ss58-codec.tgz:
-    resolution: {integrity: sha512-R4IJYj5V9Yln8Q+ohrq8znTuuqhvEVk8wwzufIgt2nskrz9TX7LAdBbboxFxK2mmWSkREG0XQMNrVpSGmgQF6A==, tarball: file:projects/ss58-codec.tgz}
+    resolution: {integrity: sha512-h0NyNnHjS4xfCYB0BsfxEPUx6ndAoLfnGkOZreDGo+25PugE9BRYwrVsL4S/VDTXsUFvBFe4bCd+vWaDKZz5VQ==, tarball: file:projects/ss58-codec.tgz}
     name: '@rush-temp/ss58-codec'
     version: 0.0.0
     dependencies:
@@ -7716,7 +7754,7 @@ packages:
     dev: false
 
   file:projects/ss58.tgz:
-    resolution: {integrity: sha512-pNuk4bx8oGlly8WNB9G3JxJl8d9mIAC8wEwOdi2Wfgu8cC/X7EDPOPSPC57WZ7/prsKYtiFUkZGm3jSJOkKURA==, tarball: file:projects/ss58.tgz}
+    resolution: {integrity: sha512-/6xAZ6f8EQBY+Yu0fYZ5Bse2wRU+8/TLfPpsR99p8AGJt9tiLj0YBc55Yh/UUJpQgymYXQj+b1ud8tamRw6WZA==, tarball: file:projects/ss58.tgz}
     name: '@rush-temp/ss58'
     version: 0.0.0
     dependencies:
@@ -7725,7 +7763,7 @@ packages:
     dev: false
 
   file:projects/starknet-data.tgz:
-    resolution: {integrity: sha512-iWdpZmVZpqs8SO47bic/gjFmJKSSRIEBuq0dTUOIn1FMUp4cLF04VuMyBMyzQXomwLqi30WydbkZY0U9I5Hqww==, tarball: file:projects/starknet-data.tgz}
+    resolution: {integrity: sha512-s6sbeLK/q9k5WzIXfkwu9SCF1uCn5yQ2cQk3mDhEAtTGpYT6qiZjPCjIdyntpf50FSBZRVlE7yg/VZUdSWLkEg==, tarball: file:projects/starknet-data.tgz}
     name: '@rush-temp/starknet-data'
     version: 0.0.0
     dependencies:
@@ -7734,7 +7772,7 @@ packages:
     dev: false
 
   file:projects/starknet-indexer.tgz(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-HeJyoNAuFkvhayrPJ0jpPmwRUZbTfsMB5eS6BoAR68KC71NduTcqcdi6xaQ0uH+72LkFv7TJfMu+1ltaKhuSDg==, tarball: file:projects/starknet-indexer.tgz}
+    resolution: {integrity: sha512-n1VqTt88FDJPHFcU0H72M5t6cGZl1qq54JpR8eR5Rn1aVCIth/ypuEsJzv2sdWIEokEFXQmCRwA1/iR4OD/UmQ==, tarball: file:projects/starknet-indexer.tgz}
     id: file:projects/starknet-indexer.tgz
     name: '@rush-temp/starknet-indexer'
     version: 0.0.0
@@ -7765,7 +7803,7 @@ packages:
     dev: false
 
   file:projects/starknet-normalization.tgz:
-    resolution: {integrity: sha512-tp5J8SraoJX+bA986NtSaE4DjMtd+GKx7PXB1tAWalsqflJb5/MMbHeQoZ/wOTWY8bLJ1eQLOMYV6yD3NRbpeA==, tarball: file:projects/starknet-normalization.tgz}
+    resolution: {integrity: sha512-+XMLyLuzsCckFlBIeyGEfTYKigQexzmq9u2JeX6zmA+9REa4M64EB7LJKL/mOlLsVIB41KbttdOjF3EETEbkAQ==, tarball: file:projects/starknet-normalization.tgz}
     name: '@rush-temp/starknet-normalization'
     version: 0.0.0
     dependencies:
@@ -7774,7 +7812,7 @@ packages:
     dev: false
 
   file:projects/starknet-objects.tgz:
-    resolution: {integrity: sha512-km4GhDES/BsCxDDcE2DSHzbLUXuB6QrOBB7g0vJRJvRNdZbtdIo6fTRroCl1pAYPY6KTO7WWpiZZZi8DCrW5dg==, tarball: file:projects/starknet-objects.tgz}
+    resolution: {integrity: sha512-9qhmpi08De5GQcx8afv8D+e+c0PpEm4CJqpqXcLCY1IlugaBxW0mRB/xLzhnFZFvW0RHmiTmjiciwPb/45MkQg==, tarball: file:projects/starknet-objects.tgz}
     name: '@rush-temp/starknet-objects'
     version: 0.0.0
     dependencies:
@@ -7783,7 +7821,7 @@ packages:
     dev: false
 
   file:projects/starknet-stream.tgz:
-    resolution: {integrity: sha512-YDUd+y5WoXOGW7Fsp50XsavfU/fzOliEkxjh4o+nmZcZW8njvN/mzsRB4Fmq/SxftaHfgB2f2yhjtYJ9/804HA==, tarball: file:projects/starknet-stream.tgz}
+    resolution: {integrity: sha512-t670OADNdn7VXqjMBvPEzr4aZt9t1msZhJgT8TZUKshDuLPQwwXZ7E4q0ZQXh2xGgMh8IxFxCG1HrAyfaDIYfA==, tarball: file:projects/starknet-stream.tgz}
     name: '@rush-temp/starknet-stream'
     version: 0.0.0
     dependencies:
@@ -7792,7 +7830,7 @@ packages:
     dev: false
 
   file:projects/substrate-data-raw.tgz:
-    resolution: {integrity: sha512-B2OAs14a+wYk+3Eem4L57du5Nooo9pfcBwowqthW1MUCkSYsl/WTFv/9J8dlWAtYvVvz8ZgX1bmIlNC42lGr+w==, tarball: file:projects/substrate-data-raw.tgz}
+    resolution: {integrity: sha512-8CsnQO9KlDjFy5ZyshFp2u3upkIb21XAo7D82bRJHciaeDDIUPLFQW6FfnFGoVZsXG9iBInqffMWy86+voSjTQ==, tarball: file:projects/substrate-data-raw.tgz}
     name: '@rush-temp/substrate-data-raw'
     version: 0.0.0
     dependencies:
@@ -7801,7 +7839,7 @@ packages:
     dev: false
 
   file:projects/substrate-data.tgz:
-    resolution: {integrity: sha512-HuKTUzcuMFYZT+NxrkXiIyb5IuD2ehdl/hfoCMvpelwlpdneVADc2Jzbjt6fHGq9d2aeUSW3h9xHzbHbQt6LDg==, tarball: file:projects/substrate-data.tgz}
+    resolution: {integrity: sha512-u3MeQzNNXXbX7k9YTKa/m65A9c8x/xPy6H7NCur/A6zBjBoo30lRRi06BSWbNevoUGs8ufzhNUI69XaX+h/ZLw==, tarball: file:projects/substrate-data.tgz}
     name: '@rush-temp/substrate-data'
     version: 0.0.0
     dependencies:
@@ -7812,7 +7850,7 @@ packages:
     dev: false
 
   file:projects/substrate-dump.tgz:
-    resolution: {integrity: sha512-EDrbFaM78U/bNFMJeYBVlhll1ebVQafh/rEfF3pfLYgpitFxmAyEFNOginrKaT8YcZP3CYq12d93YvoIiQej7A==, tarball: file:projects/substrate-dump.tgz}
+    resolution: {integrity: sha512-+HwLPV3nbDrkmMYFL83FnrsFwcFErxy8QSjZETBUBExFwK+6WbW0TG9H/HAcVoX9nL+mSpicDsd1TA7054jeaQ==, tarball: file:projects/substrate-dump.tgz}
     name: '@rush-temp/substrate-dump'
     version: 0.0.0
     dependencies:
@@ -7823,17 +7861,19 @@ packages:
     dev: false
 
   file:projects/substrate-ingest.tgz:
-    resolution: {integrity: sha512-aP4MfsS25ZwjXUqNJrjyxZqeLB6P1hNRBv5ANu5gkSYcFVLm/j4h3hHozk5QHzbJthlOcWV08OJUXgFAU5kcJQ==, tarball: file:projects/substrate-ingest.tgz}
+    resolution: {integrity: sha512-fs3/MBcPg32aRTIhlGAGAM94SyBOQ32vHupl7ZgIDo7+kqKIBGprKViQUV1tYRLsx54ZYaa7InhkwXfCoWi9aQ==, tarball: file:projects/substrate-ingest.tgz}
     name: '@rush-temp/substrate-ingest'
     version: 0.0.0
     dependencies:
+      '@prisma/client': 4.16.2(prisma@4.16.2)
       '@types/node': 18.19.0
       commander: 11.1.0
+      prisma: 4.16.2
       typescript: 5.5.4
     dev: false
 
   file:projects/substrate-metadata-explorer.tgz:
-    resolution: {integrity: sha512-d2TL0AE3R6kAhHTjWaEcIcsHZxo+UFRhyohwNmTpKIqb4UX3V5LvKldmh6QtBQm1tZpi9ZNmC+uFisCRByfWaQ==, tarball: file:projects/substrate-metadata-explorer.tgz}
+    resolution: {integrity: sha512-GsvZAG9nZ/WLCxnqf5LeZD6yNymgn2JrhLReAJgqEGSUntBVepc7Qpk4dmJnLTfDz/GmH456ZwngyjxfKiaVHw==, tarball: file:projects/substrate-metadata-explorer.tgz}
     name: '@rush-temp/substrate-metadata-explorer'
     version: 0.0.0
     dependencies:
@@ -7843,7 +7883,7 @@ packages:
     dev: false
 
   file:projects/substrate-metadata-service.tgz:
-    resolution: {integrity: sha512-lvRovegHddZJmoIPfCdG4riRuj7YDUGo0n9873bzQfg8FygyDHG/Lg4mpW71EewP3Zz4eRFGWogWNzA2KjLfjA==, tarball: file:projects/substrate-metadata-service.tgz}
+    resolution: {integrity: sha512-aVPXPUd2WQwXbJxg3SdDA2hBckf6TBs2CbdsY+IhmGN6HJd9oalCLCX062gCA+N5IsC3k4XCT50f9a6vJg1IZg==, tarball: file:projects/substrate-metadata-service.tgz}
     name: '@rush-temp/substrate-metadata-service'
     version: 0.0.0
     dependencies:
@@ -7856,7 +7896,7 @@ packages:
     dev: false
 
   file:projects/substrate-processor.tgz:
-    resolution: {integrity: sha512-TdI7sH7n3a2nq1Awf1QUs+iOPpzrGULwH+pFmMRHOfWW1CdJBYfvsWhHSISbkOUX6384SUYVZXhcCqQOzD24Dg==, tarball: file:projects/substrate-processor.tgz}
+    resolution: {integrity: sha512-k9lRapIvvOjWwk0JrC0WUqBGYUZqd/8wN7B+j4h/JtjAerqcfCi0BrBnHMT1H9P8bl0EFJSkWeokCTgKcod4DQ==, tarball: file:projects/substrate-processor.tgz}
     name: '@rush-temp/substrate-processor'
     version: 0.0.0
     dependencies:
@@ -7865,7 +7905,7 @@ packages:
     dev: false
 
   file:projects/substrate-runtime.tgz:
-    resolution: {integrity: sha512-RAJVuaNkiS4lv7/oHlQYmypKmubiPDZYKzY72PCYsfgRZ7I6SAifO4nw1JuQiaNPZ9t0mRP5bmobw//g0yrIow==, tarball: file:projects/substrate-runtime.tgz}
+    resolution: {integrity: sha512-qtYUa2sfT9rVLujXnpf0AAsCiPGOLEupt4yyLf1l1rdwA53BVwEia5jWMRTTFRVMzv23HMFBMEITywB+34h5Bg==, tarball: file:projects/substrate-runtime.tgz}
     name: '@rush-temp/substrate-runtime'
     version: 0.0.0
     dependencies:
@@ -7878,7 +7918,7 @@ packages:
     dev: false
 
   file:projects/substrate-typegen.tgz:
-    resolution: {integrity: sha512-48BCcWK9hDLE++MNXeOmPGz7fsKPIIWcQkbIfkzAp2lVci0X1NqwvWAchSJNw3u4XMoKY7JSEnDm0eWGsWP/0w==, tarball: file:projects/substrate-typegen.tgz}
+    resolution: {integrity: sha512-SZBb5sSTGjm7msFmIAYtHVfmlFlNCAy5qiLPI6QGTdFluh7wvYnFh9SKoMfHXwTCyPnlX+kmUdK1gDVhp0w+FA==, tarball: file:projects/substrate-typegen.tgz}
     name: '@rush-temp/substrate-typegen'
     version: 0.0.0
     dependencies:
@@ -7888,7 +7928,7 @@ packages:
     dev: false
 
   file:projects/tron-data.tgz:
-    resolution: {integrity: sha512-sJI3DA3gbJXvQguC8AXqOBBJrAMIMPEOn0a6or+KEEASafKElUDGK5uV6uAtrQ+o8la7kh98ImQPirHS70z8kQ==, tarball: file:projects/tron-data.tgz}
+    resolution: {integrity: sha512-AnZ2mjIhDmxqQ6je661F2AzDRvUJHoZTkdqa0lWo5QScjjvvdEOGv42VAGXqPuYe4n4gY4Dj+K/eFzfeDCAQ+Q==, tarball: file:projects/tron-data.tgz}
     name: '@rush-temp/tron-data'
     version: 0.0.0
     dependencies:
@@ -7897,7 +7937,7 @@ packages:
     dev: false
 
   file:projects/tron-dump.tgz:
-    resolution: {integrity: sha512-RuFlRzpyqZzDgIPLYkgB5XT1rCwVqitDXrrwYdrmz4j8Sxo9jgaPLAPSBySfsjEMhsmGioBCTBhTz2mOXjMGpg==, tarball: file:projects/tron-dump.tgz}
+    resolution: {integrity: sha512-7mMmX8OvL53J9zv/maiHMA4xbjUU0VEulScswXJEFfVrnJxtWM4GqmliJbl2Sf+WsrPbFTULDn74sGR8PPXmsA==, tarball: file:projects/tron-dump.tgz}
     name: '@rush-temp/tron-dump'
     version: 0.0.0
     dependencies:
@@ -7912,7 +7952,7 @@ packages:
     dev: false
 
   file:projects/tron-ingest.tgz:
-    resolution: {integrity: sha512-3SUhJyFVEPHeR5dI/UtDmTxYESKinZySmlxJF5Umx7n6LMcZ/uCg4o4kyvCLL1RdTWb85yr9DU0TNFP3VPVgsA==, tarball: file:projects/tron-ingest.tgz}
+    resolution: {integrity: sha512-WnVzPjNXxR0EqKDwi5d6Y+vqc30Yitl8y4iZ7CrkrTtxUjo/CPcfm5QmVgkfkOaIbm6SDR0axJ5IfcUFkM7b/Q==, tarball: file:projects/tron-ingest.tgz}
     name: '@rush-temp/tron-ingest'
     version: 0.0.0
     dependencies:
@@ -7927,7 +7967,7 @@ packages:
     dev: false
 
   file:projects/tron-normalization.tgz:
-    resolution: {integrity: sha512-L/271VH3m66GAUU2sSeRBdy7l7H03mkqEK0InZzVWGtj0kfQTzjJZtVG/4Qou3CEORHrE4ziQZ4IML4UMORbEg==, tarball: file:projects/tron-normalization.tgz}
+    resolution: {integrity: sha512-gsjOfpFQJCC4C8XaQIXqvSfFQh7K0OBeMIPu88BljX9RSsM6saO+ub03HKxQn1GR4LWaFwE3JoHOsuuw+UAVHw==, tarball: file:projects/tron-normalization.tgz}
     name: '@rush-temp/tron-normalization'
     version: 0.0.0
     dependencies:
@@ -7936,7 +7976,7 @@ packages:
     dev: false
 
   file:projects/tron-processor.tgz:
-    resolution: {integrity: sha512-+8R5RupIg9nBRUzTiZv/l2SZnDLnowzBWi18N+4h9L5O0TDxz3mW20u1FT9xjqa7qdTAGj2bX/GJiDPJt3KSYw==, tarball: file:projects/tron-processor.tgz}
+    resolution: {integrity: sha512-1gO1lxfyVJCfeHpvN8oDfLt2okWpTJAZtOuMh+73/pJrLyEvCgqAjPgEwDlRiFjZ8v2HOd85dho80AU6bQsueg==, tarball: file:projects/tron-processor.tgz}
     name: '@rush-temp/tron-processor'
     version: 0.0.0
     dependencies:
@@ -7945,7 +7985,7 @@ packages:
     dev: false
 
   file:projects/tron-usdt.tgz(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-0QWm4fOm2dQGP2JmOnoj+PiQzlt0sqKkyqxmDHZ1bdjASHQDDLyZcEjqddYJx1UgL51grd1owQ1LH6YCFB7imQ==, tarball: file:projects/tron-usdt.tgz}
+    resolution: {integrity: sha512-vG+KAB0qC4kclrMBj6XjKn5TaW9skOeis6tF1jwmfOK7sPch9p1s2UP2PP9ay9wkdyYF0k7PxssmnxawGYrY8g==, tarball: file:projects/tron-usdt.tgz}
     id: file:projects/tron-usdt.tgz
     name: '@rush-temp/tron-usdt'
     version: 0.0.0
@@ -7976,7 +8016,7 @@ packages:
     dev: false
 
   file:projects/typeorm-codegen.tgz:
-    resolution: {integrity: sha512-Y3XSnchEh6rRT5ZaN/cGBQbziEo5e/GRrG99hpwIcy98KIkB6YnjCP7Xx1jaeD8TJ7g0Eu8D5EPy0Iz5cnGM3g==, tarball: file:projects/typeorm-codegen.tgz}
+    resolution: {integrity: sha512-0Em18D+H2UDtem//3fuBVXffaE7c6Rop5tTs+1OJ377WnttZl/y+iorZUqTQK4QVK80+BM3VtoKcnLV20hLM5g==, tarball: file:projects/typeorm-codegen.tgz}
     name: '@rush-temp/typeorm-codegen'
     version: 0.0.0
     dependencies:
@@ -7986,7 +8026,7 @@ packages:
     dev: false
 
   file:projects/typeorm-config.tgz(pg@8.11.3)(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-zQrq7TNo6u62oSZFRbPpDpwBefnbyxtCBbYiTrwli8rXTl4yjMHDo8TwYXFGpwSGlHhORWFazO/JK/xxwLEbEw==, tarball: file:projects/typeorm-config.tgz}
+    resolution: {integrity: sha512-eNwfLU3oTSsMVLtpDYgzNav/FJmtltQF0yCunLhRu1U/7vSncPKuXEd5kz1abbP7KWH21Gtp4lgqoAwH/7Ww9A==, tarball: file:projects/typeorm-config.tgz}
     id: file:projects/typeorm-config.tgz
     name: '@rush-temp/typeorm-config'
     version: 0.0.0
@@ -8016,7 +8056,7 @@ packages:
     dev: false
 
   file:projects/typeorm-migration.tgz(pg@8.11.3)(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-GbDKmLWtlqXqD33gFHYIHJtR8PL8pi1CQm5g95VWfEYwHAyH7nwTuMzHI4VfxfjGkKqE5F/hkTNcKAJkS1xgVA==, tarball: file:projects/typeorm-migration.tgz}
+    resolution: {integrity: sha512-CqLEoUCe9/gv6hzW5dMAQbQRFDv6N2cs9af1tltLALy11rCpFQHnBugi7xTs8kcdeSJdJWilyncYFYpnJoQECA==, tarball: file:projects/typeorm-migration.tgz}
     id: file:projects/typeorm-migration.tgz
     name: '@rush-temp/typeorm-migration'
     version: 0.0.0
@@ -8048,7 +8088,7 @@ packages:
     dev: false
 
   file:projects/typeorm-store.tgz(supports-color@8.1.1)(ts-node@10.9.2):
-    resolution: {integrity: sha512-epvErPedpawh12bbYa/Q/k9e+A5Katl3Hdtsk46qPOrNmcT7laXX9aTKFGAsZN0Fv/P2KgdkNkzZ4F5HtphnRw==, tarball: file:projects/typeorm-store.tgz}
+    resolution: {integrity: sha512-5FR40oDojipvVqsaliU4slACvS3c9AxJZGAWgHOBbhiqeNQtbnORuVc/3JsdewSb7EfxgtMg4Hq4cMYtY+ephQ==, tarball: file:projects/typeorm-store.tgz}
     id: file:projects/typeorm-store.tgz
     name: '@rush-temp/typeorm-store'
     version: 0.0.0
@@ -8082,7 +8122,7 @@ packages:
     dev: false
 
   file:projects/types-test.tgz:
-    resolution: {integrity: sha512-2E3CdDQFXq7OvQ6v8E+sBF0ylk97gVzpQTKSDzQvnPmF3fgvRvUNTrxnJ8poQJKbsfKOVqPh0cLPcAn7gqmHhQ==, tarball: file:projects/types-test.tgz}
+    resolution: {integrity: sha512-q9i9XIZ+i9rPQv3fcJyz96Z3gnxjXSYd5ky2f7fpVW437rvXErrwg7iNL+9mPcUHTlQDgTuNEuxvISf4zfGkdA==, tarball: file:projects/types-test.tgz}
     name: '@rush-temp/types-test'
     version: 0.0.0
     dependencies:
@@ -8091,7 +8131,7 @@ packages:
     dev: false
 
   file:projects/util-internal-archive-client.tgz:
-    resolution: {integrity: sha512-3BxsJgUxqeE9+LTRaTTlyLjN3ccZN9z2P2PpcZ+7P2aq/yjb1FhJanSXZcXax1umCbAs+rZLx0x1sXpRdY3xQQ==, tarball: file:projects/util-internal-archive-client.tgz}
+    resolution: {integrity: sha512-LbICwivbbRy0u1T4cX4+6+M9xF8/tXgmvIcjQhmaMmwi1r803a5rh7RvccEKoLoCvrhWvL3UTGegBhydcLtcEg==, tarball: file:projects/util-internal-archive-client.tgz}
     name: '@rush-temp/util-internal-archive-client'
     version: 0.0.0
     dependencies:
@@ -8100,7 +8140,7 @@ packages:
     dev: false
 
   file:projects/util-internal-archive-layout.tgz:
-    resolution: {integrity: sha512-LGPhSaPzTZEwJ7tGyXreNXxTQe5UKsIHPwtAdpYtXwLXrmn6ye1W2Ht7kh6IUQc1Nf2k66nXK3KgPC0pn4U5zA==, tarball: file:projects/util-internal-archive-layout.tgz}
+    resolution: {integrity: sha512-k+IlWx59L2L9os/Va0ADhElUpa8DdNenyJiE3gmLngi0YVLlf8RGTu3EDW7GbNvVl6QymmiDqbdRENepOeHM0g==, tarball: file:projects/util-internal-archive-layout.tgz}
     name: '@rush-temp/util-internal-archive-layout'
     version: 0.0.0
     dependencies:
@@ -8109,13 +8149,13 @@ packages:
     dev: false
 
   file:projects/util-internal-binary-heap.tgz:
-    resolution: {integrity: sha512-ySQbSVAEksbM/fIDa9Ze8c5xmo7GoKCaI5ox7AB7vAxFSb0oQ+KQelUdJIzA2I4kWnJ3K7dCbPCZlADICAUO/w==, tarball: file:projects/util-internal-binary-heap.tgz}
+    resolution: {integrity: sha512-FuCabuHvxL94nHw4H0bzUVMgMOwsr+BOhczLUhneQijzQAQpGhq/uYBbzQgjsY/AtqMBe2hciv0Xq0kf2DcI1g==, tarball: file:projects/util-internal-binary-heap.tgz}
     name: '@rush-temp/util-internal-binary-heap'
     version: 0.0.0
     dev: false
 
   file:projects/util-internal-code-printer.tgz:
-    resolution: {integrity: sha512-NT3PdowQN519LZMG5NRYHvVyKG1vaIZPw8Hyc5V6mjCyARGZl8GwV553ijslkRTxucFftJyfXJbnqFje9UeZ0w==, tarball: file:projects/util-internal-code-printer.tgz}
+    resolution: {integrity: sha512-F/BontDlT0a3/lB9GHOlHfBBBV6rfg7KSIq9flRVu1g1RilAc1Zw0whzNGEIp0ysfj3rubHZkYXYY1YmhOo2iw==, tarball: file:projects/util-internal-code-printer.tgz}
     name: '@rush-temp/util-internal-code-printer'
     version: 0.0.0
     dependencies:
@@ -8124,7 +8164,7 @@ packages:
     dev: false
 
   file:projects/util-internal-commander.tgz:
-    resolution: {integrity: sha512-kS3JO/i4h5zCoPcU3Dxw/lIzlFEpFbvkehvAnLam+n2U9Q3JI9Zmr317hD4hFhlK7bQV7so1XSChfOtPyOKKeA==, tarball: file:projects/util-internal-commander.tgz}
+    resolution: {integrity: sha512-uTE+v2lXPIo9R3G1itMI2tIFrySLLUvbLjeDBVK6C3YZ3acf8MQQWw5Nf0SVtt3R4DgM8ptxwKcWaQFc3BrS2A==, tarball: file:projects/util-internal-commander.tgz}
     name: '@rush-temp/util-internal-commander'
     version: 0.0.0
     dependencies:
@@ -8134,7 +8174,7 @@ packages:
     dev: false
 
   file:projects/util-internal-config.tgz:
-    resolution: {integrity: sha512-ukaL8K+7hpVjgbM7VBotuqPuyJnALkZqtn4LhuLMRrp4CyuUQcVMyA519fnaZImwnH2kZeTQWVRBMYmO4aE6ZQ==, tarball: file:projects/util-internal-config.tgz}
+    resolution: {integrity: sha512-2sIaBJCkDEtK/Ejv5xHiL/lGQ24AP9PbGXnULvIPRv5VloN+tOhuJRxblVNMxtITYJ5zP6IiCEQI5Ebuqi/MLg==, tarball: file:projects/util-internal-config.tgz}
     name: '@rush-temp/util-internal-config'
     version: 0.0.0
     dependencies:
@@ -8145,7 +8185,7 @@ packages:
     dev: false
 
   file:projects/util-internal-counters.tgz:
-    resolution: {integrity: sha512-c7P1NOiAx6NR2dJxeb0vZ2UPyCkrXATgGN9pmiNrfNNvJteK2p0DROfTSeM/2hY4lwXThHuwzxXh/nkrt/4DOg==, tarball: file:projects/util-internal-counters.tgz}
+    resolution: {integrity: sha512-FSNzbkw0HlAGtcOTxoNaFr+lKkSp4blvK6wuTes+WUDE4OvYPBGqoCXrdeaOhwabOeFC1CxFu50zjrtfT2S+Qg==, tarball: file:projects/util-internal-counters.tgz}
     name: '@rush-temp/util-internal-counters'
     version: 0.0.0
     dependencies:
@@ -8154,7 +8194,7 @@ packages:
     dev: false
 
   file:projects/util-internal-dump-cli.tgz:
-    resolution: {integrity: sha512-bYRN5LlkwO3SJSm3ZrEQs/BLnzaEm27H8F6IXwljnmWgmsNyZ8icSRfTeeAvbMOtjsWYr2YfyW68iQbUk6UqgA==, tarball: file:projects/util-internal-dump-cli.tgz}
+    resolution: {integrity: sha512-XK3RAHD0aqDXHt9aDHcBKln6TFb3P9LhLWMXDgd/PU4zpfYaeAxrmyQK6AmpavpyS7Wewnw1am3OeNaVnGVv5w==, tarball: file:projects/util-internal-dump-cli.tgz}
     name: '@rush-temp/util-internal-dump-cli'
     version: 0.0.0
     dependencies:
@@ -8165,7 +8205,7 @@ packages:
     dev: false
 
   file:projects/util-internal-fs.tgz:
-    resolution: {integrity: sha512-5ZzAJFRmJNPa//etnf9bVel2hZAD2GWAhCXGG3ZdNg3hbtj7FLsfwGauSqO0+TxgGEe4t+NtVabhHagpCqDDqQ==, tarball: file:projects/util-internal-fs.tgz}
+    resolution: {integrity: sha512-3R1AWTLysAYSce2f/RmAhxzgzTfzDrMn0R0bimDwX+IUU3dIWj1qkkZjTHlSr8p4zjDMLWPINF0vMfUoVcojSA==, tarball: file:projects/util-internal-fs.tgz}
     name: '@rush-temp/util-internal-fs'
     version: 0.0.0
     dependencies:
@@ -8178,7 +8218,7 @@ packages:
     dev: false
 
   file:projects/util-internal-hex.tgz:
-    resolution: {integrity: sha512-UqXwRMUHySO0yTyTVoGQ7S3LPSZtZy8mkAO5Wt0sKsXvKKa0Jo8snF4OAHyMOxiekoh0elVcnz/pD3YTngia+g==, tarball: file:projects/util-internal-hex.tgz}
+    resolution: {integrity: sha512-xTV8Ehbm5d29ZeuPpIyBV9Et3COLLqLeIVxOX7Mk1mBhxqKMpiWqLHSJFy6FH/H8LMCHluDLgrQ13hXrIAH2PA==, tarball: file:projects/util-internal-hex.tgz}
     name: '@rush-temp/util-internal-hex'
     version: 0.0.0
     dependencies:
@@ -8187,7 +8227,7 @@ packages:
     dev: false
 
   file:projects/util-internal-http-server.tgz:
-    resolution: {integrity: sha512-W8qr/8iVvnlGVpncSN+16X2P/jqRh+dSD3Q2LKfv5LmiH2jppiMRybtKv44QDWdCVN5RxJXpSf6l+Vl/P426UA==, tarball: file:projects/util-internal-http-server.tgz}
+    resolution: {integrity: sha512-lhLF0nppltTMTO7VIKuH2SB2e2NBrQhOYLXgNiWees73e9O3CARTNh0AYoAFHeHgbSoTDdBsBMvjyHfOlK7yag==, tarball: file:projects/util-internal-http-server.tgz}
     name: '@rush-temp/util-internal-http-server'
     version: 0.0.0
     dependencies:
@@ -8198,7 +8238,7 @@ packages:
     dev: false
 
   file:projects/util-internal-ingest-cli.tgz:
-    resolution: {integrity: sha512-n0jqAOmNqGw0DR2+Rb0viiPvcH5Ff1yz8NvXrRO1pZHDa62aCSYwcCkL2djJ670bbQA4WUnZtY27AlrF8Yz38w==, tarball: file:projects/util-internal-ingest-cli.tgz}
+    resolution: {integrity: sha512-rzPGHs0OZett1Xp6DXaQukgYvPEW4HmFGsFQYsznuUTxb1q7SKzuFtQ3I5RKyFtcRXBSn1Fvkk+wxnKH+a1Wtg==, tarball: file:projects/util-internal-ingest-cli.tgz}
     name: '@rush-temp/util-internal-ingest-cli'
     version: 0.0.0
     dependencies:
@@ -8209,7 +8249,7 @@ packages:
     dev: false
 
   file:projects/util-internal-ingest-tools.tgz:
-    resolution: {integrity: sha512-DrzCx8KOXaTOTV7xWmxxfM1n7SPk9jYacULlFhRw0ZdlAfFsdyjSGO2daM3N0clz8jaxo30GsAVFETZ6iQ7uGg==, tarball: file:projects/util-internal-ingest-tools.tgz}
+    resolution: {integrity: sha512-wfDaDDuPvVhuuf5m1jHNOkh9B/SXQUaqh5UmdvcDlPUtTd1UqobJix5ERkzktZsfx3/LhgzvphWf2IKgSYScJg==, tarball: file:projects/util-internal-ingest-tools.tgz}
     name: '@rush-temp/util-internal-ingest-tools'
     version: 0.0.0
     dependencies:
@@ -8218,7 +8258,7 @@ packages:
     dev: false
 
   file:projects/util-internal-json-fix-unsafe-integers.tgz:
-    resolution: {integrity: sha512-zNuy1L62STpEIn39hdZqr2j0usxxEd2GYWBdSPhVf27oUHDQH7ZhdYGZrC5Yh9u/Mmho6mK/dUc+EoKSscHCdQ==, tarball: file:projects/util-internal-json-fix-unsafe-integers.tgz}
+    resolution: {integrity: sha512-s87GTU0NrQS7uWAC6vi5AT7erIrTQRYcDH9Cy/dwbHFJoObtSISX3WjK37yDfATjGq/Lc59m7jBXyLgdBFkn0g==, tarball: file:projects/util-internal-json-fix-unsafe-integers.tgz}
     name: '@rush-temp/util-internal-json-fix-unsafe-integers'
     version: 0.0.0
     dependencies:
@@ -8227,7 +8267,7 @@ packages:
     dev: false
 
   file:projects/util-internal-json.tgz:
-    resolution: {integrity: sha512-WskwHbFr3/m6Yy7fGlr2tRe7z/TRlOYSRxkiX3vrjnJgHJy2I5PbdDLPw9Ew9oyQZtOyjmXEjpi48oxh/Hk7BQ==, tarball: file:projects/util-internal-json.tgz}
+    resolution: {integrity: sha512-yi74Jnv4cCll8SXd3V24zoGW1RYB/8cHh4nTFtzDOOahcmQWXSN2ls+0feQKMuJpBwYzKM5sv/drdj6se3SaUw==, tarball: file:projects/util-internal-json.tgz}
     name: '@rush-temp/util-internal-json'
     version: 0.0.0
     dependencies:
@@ -8236,7 +8276,7 @@ packages:
     dev: false
 
   file:projects/util-internal-processor-tools.tgz:
-    resolution: {integrity: sha512-tiJ3mK2240qTUAriM2K6xQtP8/Z0+Nxbo5QUeTif3dmcrUg9/adg3bHBPPXOatW3bSTHyu9pIiibq9fy9CDL8A==, tarball: file:projects/util-internal-processor-tools.tgz}
+    resolution: {integrity: sha512-woBjM8tOP4lwXRC4eks5RKHsRZdlwNnuRg4SI9rodMViBHrO1sCmXew5g0p4mmEtbbUOzCx0O2jFaTS4IjjykQ==, tarball: file:projects/util-internal-processor-tools.tgz}
     name: '@rush-temp/util-internal-processor-tools'
     version: 0.0.0
     dependencies:
@@ -8246,7 +8286,7 @@ packages:
     dev: false
 
   file:projects/util-internal-prometheus-server.tgz:
-    resolution: {integrity: sha512-hIya87a+kSmqpmEAWjfIjobXBCX2hnyOiX8VuckwynunejlY/mrj9/2v1dNPTXhyTk3MUVJWr2oTaZtmSSByYA==, tarball: file:projects/util-internal-prometheus-server.tgz}
+    resolution: {integrity: sha512-mTWgKBojS6lbiW97pmDalAOPIjLlnTEVG9KqWWbLdps0x2zBTEfu5hFXvyf+Cpd3Gb0HA7qYubVKFuekoEoUeQ==, tarball: file:projects/util-internal-prometheus-server.tgz}
     name: '@rush-temp/util-internal-prometheus-server'
     version: 0.0.0
     dependencies:
@@ -8256,7 +8296,7 @@ packages:
     dev: false
 
   file:projects/util-internal-range.tgz:
-    resolution: {integrity: sha512-cd6n9nsfKHw7W9Ke5+Hb809b3KOP2VwyD00DZhA3e1z4/jrPFkIwxjmwBEHB3prSyL0WyOV2ZmtGgs5AUX4zBQ==, tarball: file:projects/util-internal-range.tgz}
+    resolution: {integrity: sha512-VOjuZLnmdBYTJxxfqmBUhMP1FQ3Zg6RzH/vLodg+agyV4L0TtHtbcbpGiMjWJtgBMpcc8V3wagcKw2NqvPIZXw==, tarball: file:projects/util-internal-range.tgz}
     name: '@rush-temp/util-internal-range'
     version: 0.0.0
     dependencies:
@@ -8266,7 +8306,7 @@ packages:
     dev: false
 
   file:projects/util-internal-read-lines.tgz:
-    resolution: {integrity: sha512-oWDP6UtB+lo4abgfen3wbHTvFJfCGQ4CPd2q4qLs4hCQZGSTvgMJATWr2Yy3oTMuDyv11Iiwke9zUfqAR0zysA==, tarball: file:projects/util-internal-read-lines.tgz}
+    resolution: {integrity: sha512-jVnlpe41GLFrvb5sNMR8sndfiaTaKtj4QaawGR6qxZt6KQyd6JuQw7NLi3SubuFm7oyyQGx6mSNFqTEEHr6XsA==, tarball: file:projects/util-internal-read-lines.tgz}
     name: '@rush-temp/util-internal-read-lines'
     version: 0.0.0
     dependencies:
@@ -8275,7 +8315,7 @@ packages:
     dev: false
 
   file:projects/util-internal-squid-id.tgz:
-    resolution: {integrity: sha512-4nQUZZLZreHv1hkq4b9flVb4HiUcIdkdsEt/0yXFVMzQ13UaMImqdwzAFNSfI7okZHaboCE+xDyimF2tYJqjjg==, tarball: file:projects/util-internal-squid-id.tgz}
+    resolution: {integrity: sha512-ZgXVEOe7gasL3vs40vrpcQKBaDYpPm/6QLTtn2IkliYKcEW2i/q5ktTCR2AcyNZF7WYVyPlp2LSMDTpw/eNHSw==, tarball: file:projects/util-internal-squid-id.tgz}
     name: '@rush-temp/util-internal-squid-id'
     version: 0.0.0
     dependencies:
@@ -8284,7 +8324,7 @@ packages:
     dev: false
 
   file:projects/util-internal-ts-node.tgz:
-    resolution: {integrity: sha512-M1ZikUD+pkhUMKyfenJMNnGkZZpSsc6aCtuR+u14fwa1v+tcWl30DlWKavwF4aCz8AFloRKnvCn4lP6n3uZE5g==, tarball: file:projects/util-internal-ts-node.tgz}
+    resolution: {integrity: sha512-W1j4AkSLgTBPTgpBjMNPzLourKo4BTv3YBqwEJNTZCDvt7Hqezh/9C5jzl0SrkEyaIb7Uabw5kp4L5tK3niXjw==, tarball: file:projects/util-internal-ts-node.tgz}
     name: '@rush-temp/util-internal-ts-node'
     version: 0.0.0
     dependencies:
@@ -8293,7 +8333,7 @@ packages:
     dev: false
 
   file:projects/util-internal-validation.tgz:
-    resolution: {integrity: sha512-nC3JerYwgkjn6+BM06AFkKuYXIiYFf/EyeGR4CbHbmFCpefgErJTikuCiaiodOnAFBosv0sA3vpzE3cmVnJogQ==, tarball: file:projects/util-internal-validation.tgz}
+    resolution: {integrity: sha512-888KrEBKVJVpyxCKYrLXCpHTc+DbQu9QicH/JAJ5LBOQ+BatErXNAnX2VombY2uOlF/fhGo+gu6qtf4W7aw3fg==, tarball: file:projects/util-internal-validation.tgz}
     name: '@rush-temp/util-internal-validation'
     version: 0.0.0
     dependencies:
@@ -8302,7 +8342,7 @@ packages:
     dev: false
 
   file:projects/util-internal.tgz:
-    resolution: {integrity: sha512-rAcQ6JK7mmQ0dCxblujFUQCEwHzqFQRz0YQHNBeBbQkDGc+ycvWw+6rST+owQtbILPPzEBxntKYzuObuyLwUOQ==, tarball: file:projects/util-internal.tgz}
+    resolution: {integrity: sha512-sp6+rQO6lf19/gGQv7Js28+gHlq6TereIIhsJMrWokmJPqmpyj3jiOWYKNIfhaDIHkUtOio84DCg6IyK9mOZYA==, tarball: file:projects/util-internal.tgz}
     name: '@rush-temp/util-internal'
     version: 0.0.0
     dependencies:
@@ -8311,7 +8351,7 @@ packages:
     dev: false
 
   file:projects/util-naming.tgz:
-    resolution: {integrity: sha512-Hk0Lz5j8lzvbZuRNcH9/iNvyMqMui/MU9hpBypJdEx5cynwOnrd0p9F0N2U9T6Sx8APMokmIpos8r3WdqQD11A==, tarball: file:projects/util-naming.tgz}
+    resolution: {integrity: sha512-LEr98Nie6zwsu9yGO9zKnfCCm+FC40Ns2Vp7MWa6HXn8PgdiS10D1TaO0YoYKIB/eegcJpq4bBTYnQAhs0FKTA==, tarball: file:projects/util-naming.tgz}
     name: '@rush-temp/util-naming'
     version: 0.0.0
     dependencies:
@@ -8323,7 +8363,7 @@ packages:
     dev: false
 
   file:projects/util-timeout.tgz:
-    resolution: {integrity: sha512-/35dqbTWWwWdZ0LwmNHs8gIhLhzuIc2JeCBzwhdmCyNs24g04oGeZhedpfVaWmw2E/AdZHN0OXpxiQJykUazBg==, tarball: file:projects/util-timeout.tgz}
+    resolution: {integrity: sha512-mao7phE8WDbwBn/oxNeOBKnts1ErkUOtJdwuLqGmJwp6BIh30uq7iIEvvcSMpahnXWox256dZ5ElgVOeSmo1sQ==, tarball: file:projects/util-timeout.tgz}
     name: '@rush-temp/util-timeout'
     version: 0.0.0
     dependencies:
@@ -8332,7 +8372,7 @@ packages:
     dev: false
 
   file:projects/util-xxhash.tgz:
-    resolution: {integrity: sha512-vWz3NXnPYHiYU8CwAxqtrlZHaiiNnbqSQslDPvwJeTyLDEfkWOTCXYa3uJflBW2dc6gGwn+0kuqlXqdfkAT26Q==, tarball: file:projects/util-xxhash.tgz}
+    resolution: {integrity: sha512-US4XOYzfdpE2YlBjyPARmQEF1OhKiSGOhy10zwe770sES114iRwuoGC48GPo8BV04ToG1J+qC9ncRGA+2sKJbQ==, tarball: file:projects/util-xxhash.tgz}
     name: '@rush-temp/util-xxhash'
     version: 0.0.0
     dependencies:
@@ -8344,7 +8384,7 @@ packages:
     dev: false
 
   file:projects/workspace.tgz:
-    resolution: {integrity: sha512-GnNGhs8WBSI/hmmpkGxwwWkCUjR+H6sp1FnU2X30PyABdPJUr7BdssSgwGMdafJFPfHkXPyTulTb/jzfG7SXbg==, tarball: file:projects/workspace.tgz}
+    resolution: {integrity: sha512-69uh+7cyqhbKpiTmRVjjGSazLqZom5NmS+m+UdrZwZY2zsb/iVN6WNbqB8PkqQ/2TZ1pSvKdeWF4/ZSOBhe53g==, tarball: file:projects/workspace.tgz}
     name: '@rush-temp/workspace'
     version: 0.0.0
     dependencies:

--- a/substrate/substrate-ingest/package.json
+++ b/substrate/substrate-ingest/package.json
@@ -16,7 +16,7 @@
     "src"
   ],
   "scripts": {
-    "build": "rm -rf lib && tsc",
+    "build": "prisma generate && rm -rf lib && tsc",
     "prisma:generate": "yarn run -T prisma generate",
     "prisma:pull": "yarn run -T prisma db pull",
     "prisma:push": "yarn run -T prisma db push --skip-generate"

--- a/substrate/substrate-ingest/prisma/schema.prisma
+++ b/substrate/substrate-ingest/prisma/schema.prisma
@@ -2,7 +2,6 @@ generator client {
   provider        = "prisma-client-js"
   output          = "../prisma"
   binaryTargets   = ["native", "linux-musl"]
-  previewFeatures = ["filterJson"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- Removed deprecated `filterJson` preview feature from `substrate-ingest/prisma/schema.prisma`

## Details
The `filterJson` preview feature in Prisma is now deprecated as the functionality has been promoted to stable and is available by default. This change eliminates the warning:
```
warn Preview feature "filterJson" is deprecated. The functionality can be used without specifying it as a preview feature.
```

The `CLAUDE.md` file provides essential development commands, architecture overview, and best practices for working with this Rush.js monorepo.

## Test plan
- [x] Verify Docker build completes without Prisma warnings
- [x] Confirm functionality remains unchanged (filterJson works by default)
- [x] Test that `rush build` succeeds for substrate-ingest package